### PR TITLE
changes for copy-to-clipboard

### DIFF
--- a/src/core/components/curl.jsx
+++ b/src/core/components/curl.jsx
@@ -19,8 +19,8 @@ export default class Curl extends React.Component {
     return (
       <div>
         <h4>Curl</h4>
-        <div className="copy-paste fs-block">
-          <textarea onFocus={this.handleFocus} readOnly="true" className="curl" style={{ whiteSpace: "normal" }} value={curl}></textarea>
+        <div className="copy-paste">
+          <textarea onFocus={this.handleFocus} readOnly={true} className="curl" style={{ whiteSpace: "normal" }} value={curl}></textarea>
         </div>
       </div>
     )


### PR DESCRIPTION
## What changed?
Added copy-to-clipboard functionality to copy the routes.

![image](https://user-images.githubusercontent.com/59335758/72061490-011c4a00-32fc-11ea-8243-358bfd511063.png)

